### PR TITLE
This mechanism should support randomized startup delay (master)

### DIFF
--- a/src/rabbit_peer_discovery_aws.erl
+++ b/src/rabbit_peer_discovery_aws.erl
@@ -106,7 +106,8 @@ list_nodes() ->
 -spec supports_registration() -> boolean().
 
 supports_registration() ->
-    false.
+    %% see rabbitmq-peer-discovery-aws#17
+    true.
 
 
 -spec register() -> ok.

--- a/test/rabbitmq_peer_discovery_aws_SUITE.erl
+++ b/test/rabbitmq_peer_discovery_aws_SUITE.erl
@@ -31,7 +31,8 @@ groups() ->
     [
      {unit, [], [
                  maybe_add_tag_filters,
-                 get_hostname_name_from_reservation_set
+                 get_hostname_name_from_reservation_set,
+                 registration_support
                 ]}].
 
 %%%
@@ -70,6 +71,9 @@ get_hostname_name_from_reservation_set(_Config) ->
                                reservation_set(), []))
         end}]
     }.
+
+registration_support(_Config) ->
+    ?assertEqual(rabbit_peer_discovery_aws:supports_registration(), true).
 
 %%%
 %%% Implementation


### PR DESCRIPTION
Ever since the core integration
RSD is only used with backends that support registration.

Closes #17.

[#155536889]