### PR TITLE
Take all hostnames from an `instancesSet`

### DIFF
--- a/src/rabbit_peer_discovery_aws.erl
+++ b/src/rabbit_peer_discovery_aws.erl
@@ -311,12 +311,13 @@ get_node_list_from_tags(Tags) ->
 get_hostname_name_from_reservation_set([], Accum) -> Accum;
 get_hostname_name_from_reservation_set([{"item", RI}|T], Accum) ->
     InstancesSet = proplists:get_value("instancesSet", RI),
-    Item = proplists:get_value("item", InstancesSet),
-    DNSName = proplists:get_value(select_hostname(), Item),
-    if
-        DNSName == [] -> get_hostname_name_from_reservation_set(T, Accum);
-        true -> get_hostname_name_from_reservation_set(T, lists:append([DNSName], Accum))
-    end.
+    Items = [Item || {"item", Item} <- InstancesSet],
+    HostnameKey = select_hostname(),
+    Hostnames = [Hostname || Item <- Items,
+                             {HKey, Hostname} <- Item,
+                             HKey == HostnameKey,
+                             Hostname =/= ""],
+    get_hostname_name_from_reservation_set(T, Accum ++ Hostnames).
 
 get_hostname_names(Path) ->
     case api_get_request("ec2", Path) of


### PR DESCRIPTION
Before this patch, the code was only taking the first item in an `instancesSet`, using `proplists:get_value()`. Therefore it would ignore all other entries in that list. Unfortunately, if that first host was the VM running the code itself, the plugin would find no RabbitMQ nodes to cluster with.

The patch simply consists of going through all `item` entries in that `instancesSet` list.

Fixes #20.
[#153749132]