### PR TITLE
Ensure rabbit_peer_discovery_httpc:maybe_configure_inet6 is called

### DIFF
--- a/src/rabbit_peer_discovery_aws.erl
+++ b/src/rabbit_peer_discovery_aws.erl
@@ -90,7 +90,8 @@ init() ->
     %% we cannot start this plugin yet since it depends on the rabbit app,
     %% which is in the process of being started by the time this function is called
     application:load(rabbitmq_peer_discovery_common),
-    rabbit_peer_discovery_httpc:maybe_configure_proxy().
+    rabbit_peer_discovery_httpc:maybe_configure_proxy(),
+    rabbit_peer_discovery_httpc:maybe_configure_inet6().
 
 -spec list_nodes() -> {ok, {Nodes :: list(), NodeType :: rabbit_types:node_type()}}.
 


### PR DESCRIPTION
Follow-up to rabbitmq/rabbitmq-peer-discovery-common#11

References rabbitmq/rabbitmq-peer-discovery-k8s#56