### PR TITLE
return an error when an AWS API fails so that peer discovery will be retried

### DIFF
--- a/src/rabbit_peer_discovery_aws.erl
+++ b/src/rabbit_peer_discovery_aws.erl
@@ -181,7 +181,7 @@ get_autoscaling_group_node_list(Instance, Tag) ->
                         error ->
                             rabbit_log:error("Cannot discover any nodes: DescribeInstances "
                                              "API call failed.", []),
-                            {ok, {[], disc}};
+                            error;
                         Names ->
                             rabbit_log:debug("Performing autoscaling group-based discovery, hostnames: ~p", [Names]),
                             {ok, {[?UTIL_MODULE:node_name(N) || N <- Names], disc}}
@@ -196,7 +196,7 @@ get_autoscaling_group_node_list(Instance, Tag) ->
         _ ->
             rabbit_log:warning("Cannot discover any nodes because AWS "
                                "autoscaling group description API call failed.", []),
-            {ok, {[], disc}}
+            error
     end.
 
 get_autoscaling_instances([], _, Accum) -> Accum;


### PR DESCRIPTION
## Proposed Changes

Discussion thread: https://groups.google.com/g/rabbitmq-users/c/FN1hHZS7BPs

Currently, when an AWS API call fails, the plugin swallows the error and acts as if there are no peers to cluster with. This results in nodes erroneously creating multiple clusters. This behaviour is contrary to the [current documentation](https://www.rabbitmq.com/cluster-formation.html#discovery-retries) that states that "with the AWS mechanism, EC2 API requests are retried".

Returning an error here means that [rabbitmq-server will retry with the configured values](https://github.com/rabbitmq/rabbitmq-server/blob/cd38d35639d6f23d295d56b69f3537eb0909476a/src/rabbit_peer_discovery.erl#L35:L36) and brings the behaviour inline with what the documentation says should happen.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

This seems like the smallest change I could make that would have the desired effect and I hope it stimulates a conversation.
