### PR TITLE
Return an error when an AWS API fails so that peer discovery will be retried

### DIFF
--- a/src/rabbit_peer_discovery_aws.erl
+++ b/src/rabbit_peer_discovery_aws.erl
@@ -179,9 +179,9 @@ get_autoscaling_group_node_list(Instance, Tag) ->
                     rabbit_log:debug("Performing autoscaling group discovery, found instances: ~p", [Values]),
                     case get_hostname_by_instance_ids(Values, Tag) of
                         error ->
-                            rabbit_log:error("Cannot discover any nodes: DescribeInstances "
-                                             "API call failed.", []),
-                            error;
+                            Msg = "Cannot discover any nodes: DescribeInstances API call failed",
+                            rabbit_log:error(Msg),
+                            {error, Msg};
                         Names ->
                             rabbit_log:debug("Performing autoscaling group-based discovery, hostnames: ~p", [Names]),
                             {ok, {[?UTIL_MODULE:node_name(N) || N <- Names], disc}}
@@ -194,9 +194,9 @@ get_autoscaling_group_node_list(Instance, Tag) ->
                     {ok, {[], disc}}
             end;
         _ ->
-            rabbit_log:warning("Cannot discover any nodes because AWS "
-                               "autoscaling group description API call failed.", []),
-            error
+            Msg = "Cannot discover any nodes because AWS autoscaling group description API call failed",
+            rabbit_log:warning(Msg),
+            {error, Msg}
     end.
 
 get_autoscaling_instances([], _, Accum) -> Accum;

--- a/src/rabbit_peer_discovery_aws.erl
+++ b/src/rabbit_peer_discovery_aws.erl
@@ -181,7 +181,7 @@ get_autoscaling_group_node_list(Instance, Tag) ->
                         error ->
                             rabbit_log:error("Cannot discover any nodes: DescribeInstances "
                                              "API call failed.", []),
-                            {ok, {[], disc}};
+                            error;
                         Names ->
                             rabbit_log:debug("Performing autoscaling group-based discovery, hostnames: ~p", [Names]),
                             {ok, {[?UTIL_MODULE:node_name(N) || N <- Names], disc}}
@@ -196,7 +196,7 @@ get_autoscaling_group_node_list(Instance, Tag) ->
         _ ->
             rabbit_log:warning("Cannot discover any nodes because AWS "
                                "autoscaling group description API call failed.", []),
-            {ok, {[], disc}}
+            error
     end.
 
 get_autoscaling_instances([], _, Accum) -> Accum;


### PR DESCRIPTION
This is #39 by @stefanmoser with a corrected return value.